### PR TITLE
fix: add owner_id support to towers CRUD operations

### DIFF
--- a/src/towers/model.ts
+++ b/src/towers/model.ts
@@ -4,9 +4,10 @@ import { eq, and } from 'drizzle-orm';
 import { towers } from '../db/schema';
 
 export interface Tower {
-	id: number;
+	id?: number;
 	name: string;
 	club_id: number;
+	owner_id?: number;
 	description?: string | null;
 	created_at?: Date;
 	updated_at?: Date;
@@ -94,6 +95,7 @@ export const createTower = async (db: NeonHttpDatabase<Record<string, never>>, d
 				name: data.name,
 				description: data.description,
 				club_id: data.club_id,
+				owner_id: data.owner_id,
 			})
 			.returning();
 		return { data: results };
@@ -121,6 +123,8 @@ export const updateTower = async (db: NeonHttpDatabase<Record<string, never>>, i
 				name: data.name,
 				description: data.description,
 				club_id: data.club_id,
+				owner_id: data.owner_id,
+				updated_at: new Date(),
 			})
 			.where(eq(towers.id, parseInt(id, 10)))
 			.returning();

--- a/src/towers/routes.ts
+++ b/src/towers/routes.ts
@@ -125,6 +125,7 @@ towersRouter.post('/', async (c) => {
 		const towerData: towersModel.Tower = {
 			name: data.name,
 			club_id: parseInt(clubId, 10),
+			owner_id: data.owner_id ? parseInt(data.owner_id, 10) : undefined,
 			description: data.description || undefined,
 		};
 
@@ -192,10 +193,13 @@ towersRouter.put('/:id', async (c) => {
 			);
 		}
 
-		// Set club_id from route parameter
-		const towerData = {
-			...data,
+		// Preserve existing values and update with provided data
+		const existingTower = towerCheck.data[0];
+		const towerData: towersModel.Tower = {
+			name: data.name || existingTower.name,
 			club_id: parseInt(clubId, 10),
+			owner_id: data.owner_id !== undefined ? parseInt(data.owner_id, 10) : existingTower.owner_id,
+			description: data.description !== undefined ? data.description : existingTower.description,
 		};
 
 		const result = await towersModel.updateTower(db, id, towerData as towersModel.Tower);


### PR DESCRIPTION
Add owner_id field handling to the towers model and routes to match the database schema. The owner_id field exists in the database but was not being included in create/update operations.

Changes:
- Add owner_id to Tower interface (optional field)
- Include owner_id in createTower values
- Include owner_id in updateTower set clause
- Update routes to accept and pass owner_id field
- Preserve owner_id in PUT requests if not provided
- Add updated_at timestamp refresh in updateTower

🤖 Generated with [Claude Code](https://claude.com/claude-code)