### PR TITLE
fix: address API auth and validation improvements

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -122,6 +122,7 @@ export const checkAuth = async function (c: any, next: any) {
 		});
 
 		c.set('userId', verification.sub);
+		c.set('clerkUserId', verification.sub);
 		return next();
 	} catch (error) {
 		console.error('Auth error details:', {


### PR DESCRIPTION
- Set clerkUserId in auth context to fix 403 errors on address creation
- Make description field optional when creating/updating addresses
- Allow duplicate address numbers within a club, but only one can be in_use at a time